### PR TITLE
Add ec2.amazonaws.com to Service

### DIFF
--- a/policies/ecs-role.json
+++ b/policies/ecs-role.json
@@ -4,7 +4,7 @@
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "ecs.amazonaws.com"
+        "Service": ["ecs.amazonaws.com", "ec2.amazonaws.com"]
       },
       "Effect": "Allow"
     }


### PR DESCRIPTION
Fixes the NoCredentialProviders error that appears when the ecs-agent tries to register with cluster:
http://stackoverflow.com/questions/34582908/error-registering-nocredentialproviders-no-valid-providers-in-chain-ecs-agent
