### PR TITLE
Updating template to new template style

### DIFF
--- a/templates.tf
+++ b/templates.tf
@@ -1,6 +1,6 @@
 /* template files for registry and ecs role policies */
 resource "template_file" "registry_policy" {
-  filename = "policies/registry.json"
+  template = "${file("policies/registry.json")}"
 
   vars {
     s3_bucket_name = "${var.s3_bucket_name}"
@@ -8,7 +8,7 @@ resource "template_file" "registry_policy" {
 }
 
 resource "template_file" "ecs_service_role_policy" {
-  filename = "policies/ecs-service-role-policy.json"
+  template = "${file("policies/ecs-service-role-policy.json")}"
 
   vars {
     s3_bucket_name = "${var.s3_bucket_name}"
@@ -16,7 +16,7 @@ resource "template_file" "ecs_service_role_policy" {
 }
 
 resource "template_file" "registry_task" {
-  filename = "task-definitions/registry.json"
+  template = "${file("task-definitions/registry.json")}"
 
   vars {
     s3_bucket_name        = "${aws_s3_bucket.registry.id}"


### PR DESCRIPTION
Under terraform 0.6.15, running this will give these warnings:

```
Warnings:

  * template_file.registry_policy: "filename": [DEPRECATED] Use the 'template' attribute instead.
  * template_file.ecs_service_role_policy: "filename": [DEPRECATED] Use the 'template' attribute instead.
  * template_file.registry_task: "filename": [DEPRECATED] Use the 'template' attribute instead.

No errors found. Continuing with 3 warning(s).
```

This pull request will get rid of the warnings, most likely at the expense of requiring a newer version of terraform.
